### PR TITLE
Remove function shadowing, crash on no then, add createOnAnimationCompletePromise, several new options for increased flexibility

### DIFF
--- a/Promise.brs
+++ b/Promise.brs
@@ -6,15 +6,15 @@ function createTaskPromise(taskName as string, fields = invalid as object, signa
     return promise
 end function
 
-function createObservablePromise(signalField as string, fields = invalid as object) as object
-    node = CreateObject("roSGNode", "ContentNode")
+function createObservablePromise(signalFieldType = "assocarray" as string, fields = invalid as object, signalField = "output" as string) as object
+    node = CreateObject("roSGNode", "Node")
     if fields <> invalid then node.addFields(fields)
-    node.addField(signalField, "assocarray", false)
+    node.addField(signalField, signalFieldType, false)
     promise = __createPromiseFromNode(node, signalField)
     return promise
 end function
 
-function createManualPromise()
+function createManualPromise() as object
     promise = __createPromise()
     promise.resolve = sub(val)
         m.context[m.id + "_callback"](val)
@@ -23,22 +23,35 @@ function createManualPromise()
     return promise
 end function
 
+function createOnAnimationCompletePromise(animation as object, startAnimation = true as boolean, unparent = true as boolean) as object
+    promise = __createPromiseFromNode(animation, "state")
+    promise.shouldSendCallback = function(node) as Boolean
+        if node.state = "stopped" then return true
+        return false
+    end function
+    promise.unparent = true
+
+    if startAnimation then animation.control = "start"
+    return promise
+end function
+
+
 '---------------------------------------------------------------------
 ' Everything below here is private and should not be called directly.
 '---------------------------------------------------------------------
 function __createPromiseFromNode(node as object, signalField as string) as object
     promise = __createPromise()
     node.id = promise.id
-    node.observeField(signalField, "__nodePromiseResolvedHandler")
+    node.observeFieldScoped(signalField, "__nodePromiseResolvedHandler")
     promise.node = node
     return promise
 end function
 
 function __createPromise() as object
-    id = strI(rnd(2147483647), 36)
+    id = StrI(rnd(2147483647), 36)
     promise = {
-        then: function(callback as function)
-           m.context[m.id + "_callback"] = callback
+        "then": function(callback as function)
+            m.context[m.id + "_callback"] = callback
         end function
     }
     promise.context = m
@@ -53,15 +66,30 @@ sub __nodePromiseResolvedHandler(e as object)
     node = e.getRoSGNode()
     id = node.id
     promise = m[id]
-    promise.context[id + "_callback"](promise.node)
+
+    isFunc = function (value)
+        valueType = type(value)
+        return (valueType = "roFunction") or (valueType = "Function")
+    end function
+
+    if isFunc(promise.shouldSendCallback) and promise.shouldSendCallback(node) = false then return
+
+    callback = promise.context[id + "_callback"]
+    if isFunc(callback) then callback(promise.node)
+
     promise.complete = true
 
     'clean up properly properly
-    if promise.suppressDispose = invalid
-        node.unobserveField(signalField)
+    if promise.suppressDispose = invalid then
+        node.unobserveFieldScoped(signalField)
         promise.delete("context")
         promise.delete("node")
         m.delete(id + "_callback")
         m.delete(id)
+    end if
+
+    if promise.unparent = true then
+        parent = node.getParent()
+        if parent <> invalid then parent.removeChild(node)
     end if
 end sub

--- a/Promise.brs
+++ b/Promise.brs
@@ -1,18 +1,16 @@
-function createTaskPromise(taskName as string, returnSignalFieldValue = true as boolean, fields = invalid as object, signalField = "output" as string) as object
+function createTaskPromise(taskName as string, fields = invalid as object, returnSignalFieldValue = false as boolean, signalField = "output" as string) as object
     task = CreateObject("roSGNode", taskName)
     if fields <> invalid then task.setFields(fields)
-    promise = __createPromiseFromNode(task, signalField)
-    promise.returnSignalFieldValue = returnSignalFieldValue
+    promise = __createPromiseFromNode(task, signalField, returnSignalFieldValue)
     task.control = "run"
     return promise
 end function
 
-function createObservablePromise(signalFieldType = "assocarray" as string, returnSignalFieldValue = true as boolean, fields = invalid as object, signalField = "output" as string) as object
+function createObservablePromise(signalFieldType = "assocarray" as string, fields = invalid as object, returnSignalFieldValue = false as boolean, signalField = "output" as string) as object
     node = CreateObject("roSGNode", "Node")
     if fields <> invalid then node.addFields(fields)
     node.addField(signalField, signalFieldType, false)
-    promise = __createPromiseFromNode(node, signalField)
-    promise.returnSignalFieldValue = returnSignalFieldValue
+    promise = __createPromiseFromNode(node, signalField, returnSignalFieldValue)
     return promise
 end function
 
@@ -41,12 +39,13 @@ end function
 '---------------------------------------------------------------------
 ' Everything below here is private and should not be called directly.
 '---------------------------------------------------------------------
-function __createPromiseFromNode(node as object, signalField as string) as object
+function __createPromiseFromNode(node as object, signalField as string, returnSignalFieldValue = false as boolean) as object
     promise = __createPromise()
     node.id = promise.id
     node.observeFieldScoped(signalField, "__nodePromiseResolvedHandler")
     promise.signalField = signalField
     promise.node = node
+    promise.returnSignalFieldValue = returnSignalFieldValue
     return promise
 end function
 


### PR DESCRIPTION
• Add createOnAnimationCompletePromise, allow setting output type in createObservablePromise, switch to Node where applicable for increased performance and allow using without providing callback
•Allow option of returning the signalField value directly instead of the containing node, rename val to value in createManualPromise to remove warning of shadowing, add dispose function to stop promise before finishing